### PR TITLE
Feat: contract types build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ yarn fc
 yarn ff
 ```
 
+**Contract Types**
+
+```bash
+# Generate contract types from src/contracts/*.json
+yarn compile-contract-types
+```
+
 ### Deployment
 
 The easiest way to deploy your Next.js app is to use [Vercel](https://vercel.com/), by the creators of Next.js.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "next lint",
     "fc": "npx prettier --check ./src",
-    "ff": "npx prettier --write ./src"
+    "ff": "npx prettier --write ./src",
+    "compile-contract-types": "typechain --target ethers-v5 --out-dir \"src/contracts/types\" \"src/contracts/*.json\"",
+    "postinstall": "yarn compile-contract-types"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.3",
@@ -16,6 +18,7 @@
     "@popperjs/core": "^2.11.6",
     "@rainbow-me/rainbowkit": "^0.7.1",
     "@tailwindcss/typography": "^0.5.7",
+    "@typechain/ethers-v5": "^10.1.1",
     "autoprefixer": "^10.4.12",
     "ethers": "^5.7.1",
     "next": "^12.3.1",
@@ -26,6 +29,7 @@
     "react-dom": "^18.2.0",
     "sass": "^1.55.0",
     "tailwindcss": "^3.1.8",
+    "typechain": "^8.1.1",
     "wagmi": "^0.6.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@popperjs/core": "^2.11.6",
     "@rainbow-me/rainbowkit": "^0.7.1",
     "@tailwindcss/typography": "^0.5.7",
-    "@typechain/ethers-v5": "^10.1.1",
     "autoprefixer": "^10.4.12",
     "ethers": "^5.7.1",
     "next": "^12.3.1",
@@ -29,7 +28,6 @@
     "react-dom": "^18.2.0",
     "sass": "^1.55.0",
     "tailwindcss": "^3.1.8",
-    "typechain": "^8.1.1",
     "wagmi": "^0.6.8"
   },
   "devDependencies": {
@@ -39,6 +37,8 @@
     "eslint-config-next": "^12.3.1",
     "prettier": "^2.7.1",
     "prettier-plugin-tailwindcss": "^0.1.12",
+    "@typechain/ethers-v5": "^10.1.1",
+    "typechain": "^8.1.1",
     "typescript": "^4.8.4"
   }
 }


### PR DESCRIPTION
### Description

Generate contract types from abi files using `typechain`

### How to use
- Copy all necessary contract abi files inside `src/contracts` folder
- Run command `yarn compile-contract-types`

### Example
```javascript
import type { MockContract } from 'contracts/types`;
```