### PR TITLE
Fix: remove postinstall from scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "lint": "next lint",
     "fc": "npx prettier --check ./src",
     "ff": "npx prettier --write ./src",
-    "compile-contract-types": "typechain --target ethers-v5 --out-dir \"src/contracts/types\" \"src/contracts/*.json\"",
-    "postinstall": "yarn compile-contract-types"
+    "compile-contract-types": "typechain --target ethers-v5 --out-dir \"src/contracts/types\" \"src/contracts/*.json\""
   },
   "dependencies": {
     "@headlessui/react": "^1.7.4",


### PR DESCRIPTION
### Description

- hotfix with removing `postinstall` script from `package.json` since `postinstall` script might not be run if there is no json files inside `contracts` folder

- `compile-contract-types` are good to use 🙂 

---

cc: Sorry @arisac  😢 